### PR TITLE
CircleCIのStatus Badgeを修正した

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # medical-final-report
 
-[![CircleCI](https://circleci.com/gh/i544c/medical-final-report.svg?style=svg&circle-token=7764432097490e000464dffc921c030b12784712)](https://circleci.com/gh/i544c/medical-final-report)
+[![CircleCI](https://circleci.com/gh/2017pro02/medical-final-report.svg?style=svg)](https://circleci.com/gh/2017pro02/medical-final-report)
 
 医療班の最終報告書
 


### PR DESCRIPTION
リポジトリをi544cから2017pro02に移譲したため，CircleCIの管理も2017pro02下となったが，Status
Badgeの変更をしていなかったためバッジが正しく表示されていなかった．