### PR TITLE
PDFの生成方法を修正した

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
       - checkout
       - run:
           name: Make dvi
-          command: platex report
+          command: |
+            platex report
+            platex report
       - run:
           name: Install packages
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,6 @@ workflows:
       - upload:
           requires:
             - build
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,6 @@ workflows:
       - upload:
           requires:
             - build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
今まで目次やら参照やらが上手くいっていなかった．
その原因がdviの生成であることを突き止め，またdvi生成を2度行うことで解決することが分かったので修正した．